### PR TITLE
edit course page style #199

### DIFF
--- a/app/assets/stylesheets/globals/variables.css.scss
+++ b/app/assets/stylesheets/globals/variables.css.scss
@@ -9,6 +9,9 @@ $custom-green: #008C7E; /* http://www.sunshine-library.org/q-a/ */
 $custom-green-a: #529f86;
 $flatui-peter-river: #3498db;
 $github-blockquote-gray: #777;
+//this 2 lines are used for course poster
+$length-ratio-16: 320px;
+$lenght-ratio-9: 175px;
 
 
 
@@ -19,3 +22,6 @@ $background-green: $custom-green-a;
 $background-gray: $dark-gray-a;
 $flash-background: $flatui-peter-river;
 $blockquote-color: $github-blockquote-gray;
+//this 2 lines are used for course poster
+$course-poster-width: $length-ratio-16;
+$course-poster-height: $lenght-ratio-9;

--- a/app/assets/stylesheets/sections/course.css.scss
+++ b/app/assets/stylesheets/sections/course.css.scss
@@ -4,7 +4,7 @@
 #tutorial-page {
   min-width: 100%;
   display: table;
-  padding: 0 19px;
+  padding-top: 40px;
   h3 {
     padding-top: 0;
     font-size: 24px;
@@ -15,10 +15,13 @@
     display: table-cell;
     vertical-align: top;
     background-color: white;
-    min-width: 250px;
-    padding: 22px 0;
-    position: static;
     width: 250px;
+    min-width: 250px;
+    padding-right: 10px;
+    position: static;
+    h1 {
+      margin-top: 0;
+    }
     .course-intro {
       margin-right: 10px;
       dl {
@@ -39,7 +42,7 @@
   .tutorial-content {
     display: table-cell;
     border-left: 1px solid #CCC;
-    padding: 22px 0 0 22px;
+    padding-left: 20px;
     width: 100%;
     .tutorial-description {
       margin-bottom: 20px;
@@ -66,22 +69,24 @@ div#html5-player {
 a.course-thumb {
   margin: 0 auto 10px;
   display: block;
+  border: 1px solid darken($light-gray, 20%);
+  width: 330px;
+  padding-top: 5px;
+  padding-bottom: 5px;
   .poster-area {
     margin: 0 auto;
     background-repeat: no-repeat;
     background-position: center;
     background-size: cover;
-    width: 320px;
-    height: 175px;
+    width: $course-poster-width;
+    height: $course-poster-height;
   }
-  border: 1px solid darken($light-gray, 20%);
-  width: 330px;
-  padding-top: 5px;
-  padding-bottom: 5px;
   .private-label {
-    color: green;
-    font-size: 18px;
+    color: red;
+    font-size: 12px;
     font-weight: normal;
+    vertical-align: super;
+    letter-spacing: -1px;
   }
   .course-info {
     text-align: left;
@@ -108,7 +113,42 @@ a.course-thumb {
     }
   }
 }
+
+#edit-course-delete {
+  margin-left: 5px;
+  .minibutton {
+    padding: 3px 10px;
+    vertical-align: bottom;
+  }
+}
+
 .edit-course-info-area {
+  padding-top: 5px;
+  p {
+    margin-bottom: 5px;
+  }
+  #edit-course-poster {
+    margin-bottom: 35px;
+    .poster-preview {
+      margin: 5px 0 20px;
+      width: $course-poster-width;
+      height: $course-poster-height;
+      #poster {
+        margin: 0 auto;
+        padding: 5px;
+        height: 100%;
+        max-width: $course-poster-width;
+        max-height: $course-poster-height;
+        border: 1px solid darken($light-gray, 20%);
+      }
+    }
+  }
+  #edit-course-desc {
+    margin-bottom: 35px;
+    .field {
+      margin-bottom: 8px;
+    }
+  }
 }
 
 .courses {

--- a/app/assets/stylesheets/shared/common.css.scss
+++ b/app/assets/stylesheets/shared/common.css.scss
@@ -125,6 +125,10 @@ input[type="text"].focus, #adv_code_search .focus.search-page-label, input[type=
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.075),0 0 5px rgba(81, 167, 232, 0.5);
 }
 
+input[type="submit"] {
+  padding: 10px 15px;
+}
+
 .container {
   width: 1200px;
   margin: 0 auto;

--- a/app/views/courses/_add_video.html.erb
+++ b/app/views/courses/_add_video.html.erb
@@ -49,7 +49,7 @@
             _tip.html('上传中&nbsp;&middot;&middot;&middot;');
           },
           done: function (e, data) {
-            _tip.html("视频已上传到服务器，并等待处理！");
+            _tip.html("视频上传成功！");
              $('.upload h3').text('处理完毕，视频上传成功！');
             $('a').unbind('click', false);
           },
@@ -89,10 +89,10 @@
       <br>
       <%= f.label t("video_desc") %>
       <br>
-      <%= f.text_field :desc %>
+      <%= f.text_area :desc, :size => "24x4", :id => "video_desc" %>
       <br>
       <br>
-      <%= f.submit t('confirm_to_upload_the_video'), :class => "minibutton", :disabled => true,  data: {disable_with: "submitting"},:id => "submit_video_info" %>
+      <%= f.submit t('submit_video_info'), :class => "minibutton", :disabled => true, data: {disable_with: t('saving') + "..."}, :id => "submit_video_info" %>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/_all_added_videos.html.erb
+++ b/app/views/courses/_all_added_videos.html.erb
@@ -6,7 +6,7 @@
           <i class="icon-facetime-video"></i>
           <%= video.title %>
         </a>
-        <%= link_to t('delete'), video, :method =>"delete", :class => "delete-action", :confirm => "确定删除吗?" %>
+        <%= link_to t('delete'), video, :method =>"delete", :class => "delete-action", :confirm => t('confirm_delete') %>
       <% end %>
     <% end %>
   </ul>

--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -6,11 +6,10 @@
       <h4>
         <%= course.title %>
         <% if !course.public? %>
-          <span class="private-label">PRIVATE</span>
+          <span class="private-label"><%= t('course_private') %></span>
         <% end %>
       </h4>
-      <p>  <%= course.description %> 
-      </p>
+      <p><%= course.description %></p>
     </div>
   </a>
   <div class="author">
@@ -20,8 +19,8 @@
 
   <% if current_user && current_user == course.user %>
     <ul class="course-actions">
-      <li><%= link_to t("edit"), edit_course_path(course) %></li>
-      <li><%= link_to t("delete"), course, :confirm => "Are you sure you want to delete?", :method => :delete %></li>
+      <li><%= link_to t('edit'), edit_course_path(course) %></li>
+      <li><%= link_to t('delete'), course, :confirm => t('confirm_delete'), :method => :delete %></li>
     </ul>
   <% end %>
 </div>

--- a/app/views/courses/_edit_video.html.erb
+++ b/app/views/courses/_edit_video.html.erb
@@ -12,17 +12,17 @@
         }
         else
         {
-          alert(file.name + " is not a mov or mp4 file");
+          alert("上传失败：" + file.name + " 视频格式错误，请上传mov或mp4文件");
         }
       },
       start: function(e) {
-        _tip.html('Uploading&nbsp;&middot;&middot;&middot;');
-        $('#submit_video_info').attr('value', 'Uploading...plz wait');
+        _tip.html('上传中&nbsp;&middot;&middot;&middot;');
+        $('#submit_video_info').attr('value', '上传中...请稍等');
         $('#submit_video_info').attr('disabled', 'true');
       },
       done: function (e, data) {
-        _tip.html("Upload done!");
-        $('#submit_video_info').attr('value', 'Save');
+        _tip.html("视频上传成功！");
+        $('#submit_video_info').attr('value', '保存');
         $('#submit_video_info').removeAttr('disabled');
       },
     });
@@ -31,15 +31,15 @@
 
 <div class="add-video-box">
   <div class="secondary-info">
-    <h1 id="edit-a-video"> <%= "Reupload video NO." + video.position.to_s %> </h1>
+    <h1 id="edit-a-video"> <%= t('reupload_video') + video.position.to_s %> </h1>
     <a class= "fileupload-btn button">
-      <span id="upload-tip">Select a Video to Upload</span>
+      <span id="upload-tip"><%= t('click_to_upload_a_video') %></span>
       <input id="fileupload" name="video[asset]" type="file">
     </a>
   </div>
 
   <div class="primary-info">
-    <h1> Edit the Details </h1>
+    <h1><%= t('enter_video_info') %></h1>
     <%= form_for video do |f| %>
       <br>
       <%= f.hidden_field :id %>
@@ -49,11 +49,11 @@
       <br>
       <%= f.label t("video_desc") %>
       <br>
-      <%= f.text_field :desc %>
+      <%= f.text_area :desc, :size => "24x4" %>
       <br>
       <br>
-      <%= f.submit "Save", :class => "minibutton", data: {disable_with: "saving..."},:id => "submit_video_info" %>
-      <%= link_to "Cancel", edit_course_path(video.course), :class => "minibutton"%>
+      <%= f.submit t('save'), :class => "minibutton", data: {disable_with: t('saving') + "..."},:id => "submit_video_info" %>
+      <%= link_to t('cancel'), edit_course_path(video.course), :class => "minibutton"%>
     <% end %>
   </div>
 </div>

--- a/app/views/courses/_update_form.html.erb
+++ b/app/views/courses/_update_form.html.erb
@@ -24,31 +24,21 @@
 
 
   <div class="field">
-    <%= f.label t('public') %>
-    <%= f.check_box :public %>
-  </div>
-  <br>
-  <div class="field">
-    <%= f.label t('course_title') %><br />
+    <%= f.label t('course_title') %>
     <%= f.text_field :title %>
-    <p>
+  </div>
+  <div class="field">
       <%= f.label t('course_description') %>
       (<%= t('remaining') %><span id='desc_count'></span> <%= t('characters') %>)
-    </p>
-    <p>
       <%= f.text_area :description, :size => "24x4", :id => "course_desc" %>
-    </p>
   </div>
-  <br>
   <div class="field">
-    <%= f.label t('course_description') %>
-    (<%= t('remaining') %><span id='desc_count'></span> <%= t('characters') %>)
-    <br>
-    <%= f.text_area :description, :size => "30x10", :id => "course_desc" %>
+      <%= f.label t('public') %>
+      <%= f.check_box :public %>
   </div>
-  <br>
   <div>
-    <%= f.submit t('update_course'), :class => "minibutton" %>
+    <%= f.submit t('update_course'), :class => "minibutton primary" %>
+    <%= link_to t('go_back'), @course, :class => "minibutton" %>
   </div>
 <% end %>
 

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -31,25 +31,32 @@
 <div class='container'>
   <div id="tutorial-page">
     <div class="tutorial-nav">
-      <h1><%= @course.title %></h1>
-      <% if @course.videos %>
-        <%= render "all_added_videos", :course => @course %>
-      <% end %>
+      <h1>
+        <%= @course.title %>
+        <% if current_user %>
+          <span id="edit-course-delete">
+            <%= link_to t('delete_this_course'), @course, :confirm => t('confirm_delete'), :method => :delete, :class => "minibutton" %>
+          </span>
+        <% end %>
+      </h1>
       <div class="edit-course-info-area">
-          <p><%= t('course_poster') %></p>
-          <a class= "fileupload-btn button">
+        <div id="edit-course-poster">
+          <p><%= t('course_poster') %>(<%= t('course_poster_dimension') %>)</p>
+          <div class="poster-preview"><%= image_tag @course.poster_url , :id => 'poster'%></div>
+          <a class= "fileupload-btn button primary">
             <span id="poster-upload-tip"><%= t('change_poster') %></span>
             <input id="poster-fileupload" name="course[poster]" type="file">
           </a>
-          <%= image_tag @course.poster_url , :id => 'poster'%>
+        </div>
+        <div id="edit-course-desc">
           <%= render 'update_form', :course => @course %>
+        </div>
       </div>
-      <% if current_user %>
-        <%= link_to t('go_back'), @course, :class => "minibutton" %>
-        <%= link_to t('delete_this_course'), @course, :confirm => '确定要删除吗?', :method => :delete, :class => "minibutton" %>
-      <% end %>
     </div>
     <div class="tutorial-content">
+      <% if @course.videos %>
+        <%= render "all_added_videos", :course => @course %>
+      <% end %>
       <% if current_user %>
         <%= render "add_video", :course => @course %>
       <% end %>

--- a/app/views/videos/create.js.erb
+++ b/app/views/videos/create.js.erb
@@ -1,4 +1,4 @@
 $('form#new_video').get(0).setAttribute("action", "/videos/<%= @video.id %>");
 $('form#new_video > div').append('<input name="_method" type="hidden" value="put">');
 $('input#submit_video_info').removeAttr('disabled');
-$('input#submit_video_info').get(0).setAttribute('value', 'Now Add Details to Save');
+$('input#submit_video_info').get(0).setAttribute('value', '保存视频信息');

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,3 +22,5 @@ en:
   sign_in: "Sign In"
   logout: "Sign Out"
   sharing: "sharing"
+
+  reupload_video: "Reupload video NO."

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -22,6 +22,7 @@ zh-CN:
   course_title: "课程标题(中英文均可)"
   course_intro: "课程介绍"
   course_description: "课程描述"
+  course_private: "课程未公开"
   all_courses: "全部课程"
   my_courses: "我的课程"
   edit_course: "编辑课程"
@@ -30,15 +31,17 @@ zh-CN:
   no_courses_found: "无任何课程"
 
   course_poster: "课程封面"
+  course_poster_dimension: "最佳宽高比为16：9"
   go_back: "取消修改"
-  delete_this_course: "删除本课程（慎重！）"
+  delete_this_course: "删除本课程"
+  confirm_delete: "确定要删除吗?"
   change_poster: "更换课程封面"
   click_to_upload_a_video: "点击上传视频"
   note_max_video_size_50m: "请注意视频大小不能超过50M！"
   wait_upload: "上传可能会花几分钟时间，请耐心等待哦"
   supported_video_format: "视频格式目前支持mov和mp4"
   enter_video_info: "输入视频信息"
-  confirm_to_upload_the_video: "确认上传视频"
+  submit_video_info: "保存视频信息"
   upload_new_video: "上传视频"
 
   no_classes: "课程表中还没有课"
@@ -56,6 +59,10 @@ zh-CN:
   video_title: "标题"
   video_desc: "视频描述"
   video_link: "链接"
+  save: "保存"
+  saving: "保存中"
+  cancel: "取消"
+  reupload_video: "重新上传视频NO."
 
   #blog things
   blog: "好奇博客"


### PR DESCRIPTION
- 主要是对课程编辑页面的改动，基本结构和样式有了，还需要完善。
- 把视频列表挪到右侧的考虑是，左侧的视频如果多的话，左侧的高度就会过高。但这个样式还需要完善。
- 课程封面的PRIVATE样式也有所改动。

@happypeter 看下这个改动是否有问题，我把 https://github.com/happypeter/onestep/pull/new/course_edit_page_style#L8L48 挪到了 https://github.com/happypeter/onestep/pull/new/course_edit_page_style#L7R41 。 所以缺少了这句的判断 https://github.com/happypeter/onestep/pull/new/course_edit_page_style#L8L47 （`<% if current_user %>`）。这句判断很有必要么，如果有必要的话，那是不是直接把这句判断加过去就可以？
