### PR TITLE
use order number to show order rather than order id

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,4 +1,5 @@
 class OrdersController < ApplicationController
+
   def new
     if !current_user
       redirect_to :login, :notice => t('login_first_plz')
@@ -28,7 +29,7 @@ class OrdersController < ApplicationController
       order.update_attributes(notify_id: params[:notify_id], trade_status: params[:trade_status], notify_time: params[:notify_time])
     end
     flash[:notice] = t('trade_finished')
-    redirect_to order_path(order)
+    redirect_to order_path(:out_trade_no => order.out_trade_no)
   end
 
   def notify
@@ -47,9 +48,16 @@ class OrdersController < ApplicationController
     end
   end
 
-  #TODO:need auth check
   def show
-    @order = Order.find(params[:id])
+    if current_user.nil?
+      redirect_to :root, :notice => t('login_first_plz')
+      return
+    end
+    @order = Order.where(:out_trade_no => params[:out_trade_no],
+                         :user_id => current_user.id).first
+    if @order.nil?
+      return
+    end
     @course_id =@order.course_id
     @course = Course.find(@course_id)
     @subject = @course.title

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -14,17 +14,25 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <td><%= @subject %></td>
-          <td>￥<%= @price %></td>
-          <td>1</td>
-          <td>￥<%= @total_fee %></td>
-          <td><%= @order.out_trade_no %></td>
-          <td><%= @notify_time %></td>
-          <td><%= @trade_status %></td>
-        </tr>
+        <% if @order.present? %>
+          <tr>
+            <td><%= @subject %></td>
+            <td>￥<%= @price %></td>
+            <td>1</td>
+            <td>￥<%= @total_fee %></td>
+            <td><%= @order.out_trade_no %></td>
+            <td><%= @notify_time %></td>
+            <td><%= @trade_status %></td>
+          </tr>
+        <% else %>
+          <tr>
+            <td colspan="7"> 没有已付款记录 </td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   </div>
-  <%= link_to t("go_back"), course_path(@course), class: "button primary" %>
+  <% if @order.present? %>
+    <%= link_to t("go_back"), course_path(@course), class: "button primary" %>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,8 @@ Onestep::Application.routes.draw do
   post '/checkout' => "orders#checkout"
   get '/orders/done' => "orders#done"
   post '/orders/notify' => "orders#notify"
-  resources :orders
+  resources :orders, except: :show
+  get '/orders/:out_trade_no' => "orders#show", :as => "order"
 
   get "about" => "about#main", :as => "about"
   get "about/team" => "about#team"


### PR DESCRIPTION
- url中使用out_trade_no来显示订单，不用order_id
- 增加了权限判断，用户只能看到自己的订单
- 增加对order为nil时的处理
- 没有处理course被删除的情况，我觉得暂时不需要。现在只是付款之后才show order，如果要查看订单的详情，在之后的index里面做
