### PR TITLE
course purchase bug fix

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -7,7 +7,7 @@ class OrdersController < ApplicationController
   def new
     @subject = @course.title
     @price = @course.price
-    @out_trade_no = Base64.encode64("#{current_user.id}: #{Time.now.to_i}")
+    @out_trade_no = Base64.urlsafe_encode64("#{current_user.id}: #{Time.now.to_i}")
 
     unless ( @order = Order.not_paid.where(course_id: params[:course_id], user_id: current_user.id).first )
       @order = current_user.orders.new


### PR DESCRIPTION
上周申请的支付宝今天才下来
实际用了下， 之前没实测的支付部分果然出了点问题

生成out_trade_no的地方， 现在用`Base64.urlsafe_encode64`替换了之前的`Base64.encode64`
